### PR TITLE
Added new sa4-boundary-table argument

### DIFF
--- a/locality-clean.py
+++ b/locality-clean.py
@@ -45,10 +45,8 @@ def main():
 
     # set command line arguments
     args = set_arguments()
-    print(args)
     # get settings from arguments
     settings = get_settings(args)
-    print(settings)
     # connect to Postgres
     try:
         pg_conn = psycopg2.connect(settings['pg_connect_string'])

--- a/locality-clean.py
+++ b/locality-clean.py
@@ -45,10 +45,10 @@ def main():
 
     # set command line arguments
     args = set_arguments()
-
+    print(args)
     # get settings from arguments
     settings = get_settings(args)
-
+    print(settings)
     # connect to Postgres
     try:
         pg_conn = psycopg2.connect(settings['pg_connect_string'])
@@ -127,7 +127,9 @@ def set_arguments():
         '--admin-schema', default='admin_bdys_' + psma_version,
         help='Destination schema name to store final admin boundary tables in. Defaults to \'admin_bdys_'
              + psma_version + '\'.')
-
+    parser.add_argument(
+        '--sa4-boundary-table', default='abs_2016_sa4',
+        help='SA4 table name used to create state boundaries. Defaults to \'abs_2016_sa4\'. Other options are: \'abs_2011_sa4\'')
     # output directory
     parser.add_argument(
         '--output-path', required=True,
@@ -144,6 +146,7 @@ def get_settings(args):
     settings['psma_version'] = args.psma_version
     settings['gnaf_schema'] = args.gnaf_schema
     settings['admin_bdys_schema'] = args.admin_schema
+    settings['sa4_boundary_table'] = args.sa4_boundary_table
     settings['output_path'] = args.output_path
 
     # create postgres connect string

--- a/postgres-scripts/01a-create-states-from-sa4s.sql
+++ b/postgres-scripts/01a-create-states-from-sa4s.sql
@@ -1,7 +1,7 @@
 
 -- create a state boundary table from sa4s (it looks visually better than the PSMA states table due to issues around bays e.g. Botany Bay, NSW) - 5 mins
 
--- dissolve polygons for each state -- 2 mins -- 6725
+-- dissolve polygons for each state -- 2 mins -- 6725 
 DROP TABLE IF EXISTS admin_bdys.temp_states;
 CREATE UNLOGGED TABLE admin_bdys.temp_states
 (
@@ -34,7 +34,7 @@ ALTER TABLE admin_bdys.temp_states CLUSTER ON temp_states_geom_idx;
 ANALYZE admin_bdys.temp_states;
 
 
--- create states as lines -- 6728
+-- create states as lines -- 6728 
 DROP TABLE IF EXISTS admin_bdys.temp_state_lines;
 CREATE TABLE admin_bdys.temp_state_lines(
   gid SERIAL NOT NULL,
@@ -59,7 +59,7 @@ ANALYZE admin_bdys.temp_state_lines;
 
 -- create state borders as buffers -- 2 min
 
--- create buffered borders -- 4538
+-- create buffered borders -- 4538 
 DROP TABLE IF EXISTS temp_borders;
 SELECT state,
        (ST_Dump(ST_Buffer(ST_Simplify(geom, 0.001), 0.015, 1))).geom AS geom
@@ -125,3 +125,7 @@ CREATE INDEX temp_state_border_buffers_subdivided_geom_idx ON admin_bdys.temp_st
 ALTER TABLE admin_bdys.temp_state_border_buffers_subdivided CLUSTER ON temp_state_border_buffers_subdivided_geom_idx;
 
 ANALYZE admin_bdys.temp_state_border_buffers_subdivided;
+
+
+
+

--- a/postgres-scripts/01a-create-states-from-sa4s.sql
+++ b/postgres-scripts/01a-create-states-from-sa4s.sql
@@ -1,7 +1,7 @@
 
 -- create a state boundary table from sa4s (it looks visually better than the PSMA states table due to issues around bays e.g. Botany Bay, NSW) - 5 mins
 
--- dissolve polygons for each state -- 2 mins -- 6725 
+-- dissolve polygons for each state -- 2 mins -- 6725
 DROP TABLE IF EXISTS admin_bdys.temp_states;
 CREATE UNLOGGED TABLE admin_bdys.temp_states
 (
@@ -20,7 +20,7 @@ INSERT INTO admin_bdys.temp_states (state, geom)
     SELECT state, ST_Union(ST_MakePolygon(geom)) As geom
     FROM (
         SELECT state, ST_ExteriorRing((ST_Dump(geom)).geom) As geom
-        FROM admin_bdys.abs_2011_sa4
+        FROM admin_bdys.sa4_boundary_table
         ) s
     GROUP BY state
   ) AS sqt;
@@ -34,7 +34,7 @@ ALTER TABLE admin_bdys.temp_states CLUSTER ON temp_states_geom_idx;
 ANALYZE admin_bdys.temp_states;
 
 
--- create states as lines -- 6728 
+-- create states as lines -- 6728
 DROP TABLE IF EXISTS admin_bdys.temp_state_lines;
 CREATE TABLE admin_bdys.temp_state_lines(
   gid SERIAL NOT NULL,
@@ -59,7 +59,7 @@ ANALYZE admin_bdys.temp_state_lines;
 
 -- create state borders as buffers -- 2 min
 
--- create buffered borders -- 4538 
+-- create buffered borders -- 4538
 DROP TABLE IF EXISTS temp_borders;
 SELECT state,
        (ST_Dump(ST_Buffer(ST_Simplify(geom, 0.001), 0.015, 1))).geom AS geom
@@ -125,7 +125,3 @@ CREATE INDEX temp_state_border_buffers_subdivided_geom_idx ON admin_bdys.temp_st
 ALTER TABLE admin_bdys.temp_state_border_buffers_subdivided CLUSTER ON temp_state_border_buffers_subdivided_geom_idx;
 
 ANALYZE admin_bdys.temp_state_border_buffers_subdivided;
-
-
-
-

--- a/postgres-scripts/05-finalise-display-localities.sql
+++ b/postgres-scripts/05-finalise-display-localities.sql
@@ -7,7 +7,7 @@ SELECT ste.new_gid,
   FROM admin_bdys.temp_state_border_buffers_subdivided AS ste
   INNER JOIN admin_bdys.temp_holes AS lne
   ON ST_Touches(ste.geom, lne.geom)
-  LEFT OUTER JOIN admin_bdys.temp_holes AS hol
+  LEFT OUTER JOIN admin_bdys.temp_holes AS hol 
   ON ste.new_gid = hol.state_gid
   WHERE hol.state_gid IS NULL;
 
@@ -25,22 +25,22 @@ ALTER TABLE admin_bdys.temp_holes_distinct OWNER TO postgres;
 CREATE INDEX temp_holes_distinct_geom_idx ON admin_bdys.temp_holes_distinct USING gist (geom);
 ALTER TABLE admin_bdys.temp_holes_distinct CLUSTER ON temp_holes_distinct_geom_idx;
 
-INSERT INTO admin_bdys.temp_holes_distinct (state, geom) -- 13192 -- 15458
+INSERT INTO admin_bdys.temp_holes_distinct (state, geom) -- 13192 -- 15458 
 SELECT state, ST_MakeValid(ST_Buffer((ST_Dump(ST_Union(ST_Buffer(ST_Buffer(geom, -0.00000002), 0.00000002)))).geom, 0.0))
   FROM admin_bdys.temp_holes
   GROUP BY state;
 
 ANALYZE admin_bdys.temp_holes_distinct;
 
--- -- reset
+-- -- reset 
 -- DELETE FROM admin_bdys.temp_split_localities WHERE match_type IN ('GOOD BORDER', 'MESSY BORDER');
 -- UPDATE admin_bdys.temp_split_localities SET match_type = 'SPLIT' WHERE match_type = 'MANUAL';
 
 
 -- update locality/state border holes with locality PIDs when there is only one locality touching it (in the same state)
 
-DROP TABLE IF EXISTS admin_bdys.temp_hole_localities; -- 1 min -- 20365 -- 15677
-SELECT DISTINCT loc.locality_pid, hol.hole_gid
+DROP TABLE IF EXISTS admin_bdys.temp_hole_localities; -- 1 min -- 20365 -- 15677 
+SELECT DISTINCT loc.locality_pid, hol.hole_gid 
   INTO admin_bdys.temp_hole_localities
   FROM admin_bdys.temp_split_localities AS loc
   INNER JOIN admin_bdys.temp_holes_distinct AS hol
@@ -48,7 +48,7 @@ SELECT DISTINCT loc.locality_pid, hol.hole_gid
     AND loc.loc_state = hol.state);
 
 
--- set good matches in temp table -- 17226 -- 15249
+-- set good matches in temp table -- 17226 -- 15249 
 UPDATE admin_bdys.temp_holes_distinct AS hol
   SET locality_pid = loc.locality_pid,
       match_type = 'GOOD'
@@ -61,32 +61,32 @@ UPDATE admin_bdys.temp_holes_distinct AS hol
   AND sqt.cnt = 1;
 
 
--- Add good holes to split localities -- 17226 -- 15249
+-- Add good holes to split localities -- 17226 -- 15249 
 INSERT INTO admin_bdys.temp_split_localities (gid, locality_pid, loc_state, ste_state, match_type, geom)
 SELECT 900000000 + hole_gid,
        locality_pid,
        state AS loc_state,
        state AS ste_state,
-       'GOOD BORDER' AS match_type,
+       'GOOD BORDER' AS match_type, 
        geom
   FROM admin_bdys.temp_holes_distinct
   WHERE match_type = 'GOOD';
 
---turf the good records so we can focus on the rest -- 17226 -- 15249
+--turf the good records so we can focus on the rest -- 17226 -- 15249 
 DELETE FROM admin_bdys.temp_hole_localities AS loc
   USING admin_bdys.temp_holes_distinct AS hol
   WHERE loc.hole_gid = hol.hole_gid
   AND hol.locality_pid IS NOT NULL;
 
 
--- Delete unmatched holes that have an area < 1m2 -- 8577 -- 5171
+-- Delete unmatched holes that have an area < 1m2 -- 8577 -- 5171 
 DELETE FROM admin_bdys.temp_holes_distinct
   WHERE ST_Area(ST_Transform(geom, 3577)) < 1.0;
 
 
 -- split remaining locality/state border holes at the point where 2 localities meet the hole and add to working localities table
 
--- get locality polygon points along shared edges of remaining holes -- 15499 -- 15667
+-- get locality polygon points along shared edges of remaining holes -- 15499 -- 15667 
 DROP TABLE IF EXISTS admin_bdys.temp_hole_points_temp;
 SELECT DISTINCT *
   INTO admin_bdys.temp_hole_points_temp
@@ -100,7 +100,7 @@ SELECT DISTINCT *
       INNER JOIN admin_bdys.temp_hole_localities AS lochol ON hol.hole_gid = lochol.hole_gid
 ) AS sqt;
 
--- get unique points shared by more than 1 locality - 239 -- 226
+-- get unique points shared by more than 1 locality - 239 -- 226 
 DROP TABLE IF EXISTS admin_bdys.temp_hole_points;
 CREATE TABLE admin_bdys.temp_hole_points
 (
@@ -111,7 +111,7 @@ CREATE TABLE admin_bdys.temp_hole_points
 ) WITH (OIDS=FALSE);
 ALTER TABLE admin_bdys.temp_hole_points OWNER TO postgres;
 
-INSERT INTO admin_bdys.temp_hole_points (hole_gid, state, geom)
+INSERT INTO admin_bdys.temp_hole_points (hole_gid, state, geom) 
 SELECT hole_gid, state, geom
     FROM (
     SELECT Count(*) AS cnt, hole_gid, state, geom FROM admin_bdys.temp_hole_points_temp GROUP BY hole_gid, state, geom
@@ -244,7 +244,7 @@ SELECT 900000000 + gid,
        locality_pid,
        state AS loc_state,
        state AS ste_state,
-       'MESSY BORDER' AS match_type,
+       'MESSY BORDER' AS match_type, 
        geom
   FROM admin_bdys.temp_holes_split
   WHERE locality_pid IS NOT NULL;
@@ -263,7 +263,7 @@ UPDATE admin_bdys.temp_split_localities
   WHERE ST_Intersects(ST_SetSRID(ST_MakePoint(144.227305683, -9.39107887741), 4283), geom);
 
 
--- merge final polygons -- 3 mins -- 15565
+-- merge final polygons -- 3 mins -- 15565  
 DROP TABLE IF EXISTS admin_bdys.locality_bdys_display_full_res;
 CREATE TABLE admin_bdys.locality_bdys_display_full_res (
   locality_pid text PRIMARY KEY,
@@ -272,7 +272,7 @@ CREATE TABLE admin_bdys.locality_bdys_display_full_res (
 ) WITH (OIDS=FALSE);
 ALTER TABLE admin_bdys.locality_bdys_display_full_res OWNER TO postgres;
 
-INSERT INTO admin_bdys.locality_bdys_display_full_res (locality_pid, geom)
+INSERT INTO admin_bdys.locality_bdys_display_full_res (locality_pid, geom) 
 SELECT locality_pid,
        ST_Multi(ST_Buffer(ST_Buffer(ST_Union(geom), -0.00000001), 0.00000001))
   FROM admin_bdys.temp_split_localities
@@ -283,7 +283,7 @@ CREATE INDEX localities_display_full_res_geom_idx ON admin_bdys.locality_bdys_di
 ALTER TABLE admin_bdys.locality_bdys_display_full_res CLUSTER ON localities_display_full_res_geom_idx;
 
 
--- simplify and clean up data, removing unwanted artifacts -- 1 min -- 17731
+-- simplify and clean up data, removing unwanted artifacts -- 1 min -- 17731 
 DROP TABLE IF EXISTS admin_bdys.temp_final_localities;
 CREATE TABLE admin_bdys.temp_final_localities (
   locality_pid text,
@@ -316,7 +316,7 @@ CREATE TABLE admin_bdys.locality_bdys_display
 ) WITH (OIDS=FALSE);
 ALTER TABLE admin_bdys.locality_bdys_display OWNER TO postgres;
 
-INSERT INTO admin_bdys.locality_bdys_display(locality_pid, locality_name, postcode, state, locality_class, address_count, street_count, geom) -- 15565
+INSERT INTO admin_bdys.locality_bdys_display(locality_pid, locality_name, postcode, state, locality_class, address_count, street_count, geom) -- 15565 
 SELECT loc.locality_pid,
        loc.locality_name,
        loc.postcode,

--- a/psma.py
+++ b/psma.py
@@ -91,6 +91,8 @@ def prep_sql(sql, settings):
         sql = sql.replace(" gnaf.", " {0}.".format(settings['gnaf_schema'], ))
     if settings['admin_bdys_schema'] is not None:
         sql = sql.replace(" admin_bdys.", " {0}.".format(settings['admin_bdys_schema'], ))
+    if settings['sa4_boundary_table'] is not None:
+        sql = sql.replace(".sa4_boundary_table", ".{0}".format(settings['sa4_boundary_table'], ))
 
     if settings['pg_user'] != "postgres":
         # alter create table script to run with correct Postgres user name


### PR DESCRIPTION
## Description
Added in a new command line argument, 'sa4-boundary-table' to support using different SA4 tables for the state/coast line boundaries. 

## Motivation and Context
With the release of the 2016 ASGS boundaries, we have newer coastlines and borders. I wanted to be able to utilise these new boundaries with the existing cleaning process. 

The PR defaults to the new 'abs_2016_sa4' table. You can use the existing 2011 table by supplying the following argument:

`--sa4-boundary-table abs_2011_sa4`

## How Has This Been Tested?
Tested locally using the default and the new command line. Both generate correctly with no invalid geometries. 

## Other Affected Components:
The 2016 SA4 table was failing on the '05-finalise-display-localities.sql' step due to an invalid geometry. I altered the buffer from -0.00000001 to -0.00000002 in the 'temp_holes_distinct' step. 

